### PR TITLE
🐛 Fix: remove duplicated name in SearchFilter.js

### DIFF
--- a/resources/js/Shared/SearchFilter.js
+++ b/resources/js/Shared/SearchFilter.js
@@ -107,7 +107,6 @@ export default () => {
           autoComplete="off"
           type="text"
           name="search"
-          name="search"
           value={values.search}
           onChange={handleChange}
           placeholder="Search…"


### PR DESCRIPTION
name attribute has written twice in SearchFilter.js